### PR TITLE
Changed display property for .hidden class from "block" to "none"

### DIFF
--- a/skin/frontend/boilerplate/default/less/utilities.less
+++ b/skin/frontend/boilerplate/default/less/utilities.less
@@ -1,7 +1,7 @@
 @import "../components/bootstrap/less/utilities.less";
 
 .hidden {
-    display: block !important;
+    display: none !important;
     border: 0 !important;
     margin: 0 !important;
     padding: 0 !important;


### PR DESCRIPTION
The base utilities.less file from bootstrap does it this way, why did you change this behavior? For me it messes with my layout and reserves space for an element, that's supposed to be invisible.
