### PR TITLE
Update style.css

### DIFF
--- a/skin/frontend/boilerplate/default/dist/css/style.css
+++ b/skin/frontend/boilerplate/default/dist/css/style.css
@@ -4499,7 +4499,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
 }
 .pager .limiter select {
   display: inline;
-  width: 50px;
+  width: 60px;
 }
 .pager .pages {
   float: left;


### PR DESCRIPTION
On the category page the select that changes the number of items per page is getting cut off slightly.  The 9 is only partially visible while the 5 from '15' and 0 from '30' isn't visible at all once those items are selected.  (example page: http://magentoboilerplate.webcomm.com.au/furniture.html).

Note this width will only fix up to 2 digit options for number of products per page.  If someone adds a 3 digit option it could still be cutoff.  The cut off appears in the most recent version of Chrome and IE. 

There may also be a way to fix this by editing the drop down arrow used on the select tag, but the arrow display changes in different browsers so the CSS width fix may be the most optimum solution.
