### PR TITLE
Fixes issues with input-group-btn

### DIFF
--- a/skin/frontend/boilerplate/default/less/utilities.less
+++ b/skin/frontend/boilerplate/default/less/utilities.less
@@ -4,6 +4,10 @@
     display: block !important;
 }
 
+.bs-prototype-override.input-group-btn{
+    display: table-cell !important;
+}
+
 .hidden {
     display: none !important;
     border: 0 !important;


### PR DESCRIPTION
This fixes an issue where the prototype makes an input-group-btn div display block when it is originally display:table-cell
