### PR TITLE
Updated package.json with gulp dependencies

### DIFF
--- a/skin/frontend/boilerplate/default/package.json
+++ b/skin/frontend/boilerplate/default/package.json
@@ -1,11 +1,14 @@
 {
   "devDependencies": {
-    "gulp": "~3.4.0",
+    "gulp": "~3",
     "gulp-less": "~1.1.10",
     "gulp-notify": "~0.3.4-2",
     "gulp-minify-css": "~0.2.0",
     "gulp-uglify": "~0.1.0",
     "gulp-concat": "~2.1.7",
-    "gulp-jshint": "~1.3.4"
+    "gulp-jshint": "~1.3.4",
+    "gulp-clean": "~0.2.4",
+    "gulp-livereload": "~1.5",
+    "tiny-lr": "~0.0.7"
   }
 }


### PR DESCRIPTION
The gulpfile.js has been modified in commit 0ccd435 and some new dependencies where introduced. The package.json doesn't list them, I added the most recent version. And since gulp itself is under heavy development whenever there is an update I'll receive a warning on the command line:

```
[gulp] Warning: gulp version mismatch:
[gulp] Running gulp is 3.6.2
[gulp] Local gulp (installed in gulpfile dir) is 3.4.0
```

So I changed the gulp version to just "3".
