### PR TITLE
Update package.json to new versions

### DIFF
--- a/skin/frontend/boilerplate/default/package.json
+++ b/skin/frontend/boilerplate/default/package.json
@@ -1,11 +1,14 @@
 {
   "devDependencies": {
-    "gulp": "~3.4.0",
-    "gulp-less": "~1.1.10",
-    "gulp-notify": "~0.3.4-2",
-    "gulp-minify-css": "~0.2.0",
-    "gulp-uglify": "~0.1.0",
-    "gulp-concat": "~2.1.7",
-    "gulp-jshint": "~1.3.4"
+    "gulp": "~3",
+    "gulp-less": "~1.2",
+    "gulp-notify": "~1.2.6",
+    "gulp-minify-css": "~0.3",
+    "gulp-uglify": "~0.3",
+    "gulp-concat": "~2.2",
+    "gulp-jshint": "~1.6",
+    "gulp-clean": "~0.2",
+    "gulp-livereload": "~1.5",
+    "tiny-lr": "~0.0.7"
   }
 }


### PR DESCRIPTION
I was pulling my hair out the better part of the day because the gulp.watch task stopped working after I did an update of magento-boilerplate. Turns out the package.json still ships with some pretty outdated versions of some gulp-packages. Here's an updated version that works (again).
