### PR TITLE
Using gulp-bless to split up css file for IE support

### DIFF
--- a/app/design/frontend/boilerplate/default/layout/local.xml
+++ b/app/design/frontend/boilerplate/default/layout/local.xml
@@ -60,7 +60,10 @@
 
 			<!-- Add our assets -->
 			<action method="addCss">
-				<stylesheet>css/style.css</stylesheet>
+				<stylesheet>dist/css/style-blessed1.css</stylesheet>
+			</action>
+			<action method="addCss">
+				<stylesheet>dist/css/style.css</stylesheet>
 			</action>
 			<action method="addItem">
 				<type>skin_js</type>

--- a/skin/frontend/boilerplate/default/gulpfile.js
+++ b/skin/frontend/boilerplate/default/gulpfile.js
@@ -12,12 +12,14 @@ var clean      = require('gulp-clean');
 var livereload = require('gulp-livereload');
 var lr         = require('tiny-lr');
 var server     = lr();
+var bless      = require('gulp-bless');
 
 gulp.task('less', function() {
     return gulp.src('less/style.less')
         .pipe(less().on('error', notify.onError(function (error) {
             return 'Error compiling LESS: ' + error.message;
         })))
+        .pipe(bless())
         // .pipe(minifycss())
         .pipe(gulp.dest('dist/css'))
         .pipe(livereload(server))

--- a/skin/frontend/boilerplate/default/package.json
+++ b/skin/frontend/boilerplate/default/package.json
@@ -9,6 +9,7 @@
     "gulp-jshint": "~1.6",
     "gulp-clean": "~0.2",
     "gulp-livereload": "~1.5",
-    "tiny-lr": "~0.0.7"
+    "tiny-lr": "~0.0.7",
+    "gulp-bless": "~1"
   }
 }


### PR DESCRIPTION
I can't test this properly since I don't use OS X (gulp-notify breaks on linux servers with no gui), but this is the gist of the change we had to make so IE9 would work properly.

For issue #37
