### PR TITLE
Update livereload.js to remove protocol

### DIFF
--- a/skin/frontend/boilerplate/default/src/js/livereload.js
+++ b/skin/frontend/boilerplate/default/src/js/livereload.js
@@ -22,4 +22,4 @@
  * THE SOFTWARE.
  */
 
-document.write('<script src="http://' + (location.host || 'localhost').split(':')[0] + ':35729/livereload.js?snipver=1"></' + 'script>')
+document.write('<script src="//' + (location.host || 'localhost').split(':')[0] + ':35729/livereload.js?snipver=1"></' + 'script>')


### PR DESCRIPTION
When you force HTTPS on the front end this makes the browser throw a warning about insecure content. Removing the protocol fixes this problem