### PR TITLE
check top_in_dropdown configuration for catalog navigation

### DIFF
--- a/app/code/community/Webcomm/BootstrapNavigation/Block/Page/Html/Topmenu.php
+++ b/app/code/community/Webcomm/BootstrapNavigation/Block/Page/Html/Topmenu.php
@@ -73,7 +73,10 @@ class Webcomm_BootstrapNavigation_Block_Page_Html_Topmenu extends Mage_Page_Bloc
                     $html .= '<div class="' . $childrenWrapClass . '">';
                 }
                 $html .= '<ul class="level' . $childLevel . ' dropdown-menu">';
-                if ($childLevel == 0) {
+                if (
+                    Mage::getStoreConfig('catalog/navigation/top_in_dropdown')
+                    && $childLevel == 0
+                ) {
                     $prefix = Mage::getStoreConfig('catalog/navigation/top_in_dropdown_prefix');
                     $suffix = Mage::getStoreConfig('catalog/navigation/top_in_dropdown_suffix');
                     $html .= '<li class="level1 level-top-in-dropdown">';


### PR DESCRIPTION
The `Show Top Level Links in Dropdown` can be disabled in the catalog configuration under `System > Catalog > Catalog > Category Top Navigation > Show Top Level Links in Dropdown`.
But nothing happend, if this is disabled.

A look at the code shows that this option is'nt checked.
This will be corrected with this bugfix.

Thanks for a review and a merge.
