### PR TITLE
Add branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,9 @@
         "magento-hackathon/magento-composer-installer":"*"
     },
     "extra": {
+        "branch-alias": {
+            "dev-master": "2.0-dev"
+        },
         "magento-root-dir": "./",
         "magento-deploystrategy": "copy",
         "map": [


### PR DESCRIPTION
Could you add a branch-alias to the master and develop version? And tag a release for the master (2.0.0?) version? 
I require this package in my composer.json, but have to use dev-master now, which would obviously break when you decide to merge develop in to master sometime..