### PR TITLE
Add dropdown classes instead of duplicate parent class

### DIFF
--- a/app/code/community/Webcomm/BootstrapNavigation/Block/Page/Html/Topmenu.php
+++ b/app/code/community/Webcomm/BootstrapNavigation/Block/Page/Html/Topmenu.php
@@ -108,8 +108,8 @@ class Webcomm_BootstrapNavigation_Block_Page_Html_Topmenu extends Mage_Page_Bloc
     {
         $classes = parent::_getMenuItemClasses($item);
 
-        if ($item->hasChildren()) {
-            $classes[] = 'parent';
+        if ($item->hasChildren() && $item->getLevel() == 0) {
+            $classes[] = 'dropdown';
         }
 
         return $classes;


### PR DESCRIPTION
As I have already mentioned at the commit #24 I've no idea why the function `_getMenuItemClasses` was implemented in this way. Magento adds a "parent" item to the array at least since version 1.7.0.2.

When I compared the generated HTML output with the bootstrap docs, I noticed that a dropdown class was missing instead. So I've created this little patch.