### PR TITLE
Fixed modal dialogue

### DIFF
--- a/app/design/frontend/boilerplate/default/template/catalog/product/view/media.phtml
+++ b/app/design/frontend/boilerplate/default/template/catalog/product/view/media.phtml
@@ -71,7 +71,7 @@ $index = 0;
 ?>
 <?php if ($baseImageFile): ?>
     <div class="product-image product-image-zoom">
-        <a href="#product-media-modal" data-toggle="media" data-index="<?php echo $index++ ?>">
+        <a href="#product-media-modal" data-toggle="modal" data-index="<?php echo $index++ ?>">
             <img src="<?php echo $this->helper('catalog/image')->init($product, 'image')->resize($baseImageSize['x'], $baseImageSize['y']) ?>" alt="<?php echo $this->htmlEscape($this->getImageLabel()) ?>">
         </a>
     </div>
@@ -82,7 +82,7 @@ $index = 0;
         <ul>
             <?php foreach ($galleryImages as $image): ?>
                 <li>
-                    <a href="#product-media-modal" data-toggle="media" data-index="<?php echo $index++ ?>">
+                    <a href="#product-media-modal" data-toggle="modal" data-index="<?php echo $index++ ?>">
                         <img src="<?php echo $this->helper('catalog/image')->init($product, 'image', $image->getFile())->resize($galleryImageSize['x'], $galleryImageSize['y']) ?>" alt="<?php echo $this->htmlEscape($image->getLabel()) ?>">
                     </a>
                 </li>


### PR DESCRIPTION
The modal dialogue wouldn't pop up, which puzzled me. Then I noticed the data-toggle attribute had `media` as value, not `modal` as suggested by the Bootstrap Modal API.