### PR TITLE
[~FEATURE] Concatenate core js files

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Begin by creating a `composer.json` in the root of Magento, and ensure it has th
     ],
     "require": {
         "magento-hackathon/magento-composer-installer": "*",
-        "webcomm/magento-boilerplate": "dev-master"
+        "webcomm/magento-boilerplate": "2.0.x-dev"
     },
     "extra": {
         "magento-root-dir": "./",

--- a/app/design/frontend/boilerplate/default/layout/magentoboilerplate.xml
+++ b/app/design/frontend/boilerplate/default/layout/magentoboilerplate.xml
@@ -62,10 +62,24 @@
 				<name>varien/menu.js</name>
 			</action>
 
+			<action method="removeItem"><type>js</type><file>prototype/prototype.js</file></action>
+			<action method="removeItem"><type>js</type><file>lib/ccard.js</file></action>
+			<action method="removeItem"><type>js</type><file>prototype/validation.js</file></action>
+			<action method="removeItem"><type>js</type><file>scriptaculous/builder.js</file></action>
+			<action method="removeItem"><type>js</type><file>scriptaculous/effects.js</file></action>
+			<action method="removeItem"><type>js</type><file>scriptaculous/dragdrop.js</file></action>
+			<action method="removeItem"><type>js</type><file>scriptaculous/controls.js</file></action>
+			<action method="removeItem"><type>js</type><file>scriptaculous/slider.js</file></action>
+			<action method="removeItem"><type>js</type><file>varien/js.js</file></action>
+			<action method="removeItem"><type>js</type><file>varien/form.js</file></action>
+			<action method="removeItem"><type>js</type><file>mage/translate.js</file></action>
+			<action method="removeItem"><type>js</type><file>mage/cookies.js</file></action>
+
 			<!-- Add our assets -->
 			<action method="addCss">
 				<stylesheet>css/style.css</stylesheet>
 			</action>
+			<action method="addJs"><name>mage.js</name></action>
 			<action method="addItem">
 				<type>skin_js</type>
 				<name>js/script.js</name>

--- a/skin/frontend/boilerplate/default/gulpfile.js
+++ b/skin/frontend/boilerplate/default/gulpfile.js
@@ -32,6 +32,7 @@ var
   concat       = require('gulp-concat'),
   notify       = require('gulp-notify'),
   cache        = require('gulp-cache'),
+  merge        = require('merge-stream'),
   livereload   = require('gulp-livereload');
 
 var config = {
@@ -67,6 +68,28 @@ gulp.task('css', function() {
 
 // JS
 gulp.task('js', function() {
+  var core = [
+    '../../../../js/prototype/prototype.js',
+    '../../../../js/lib/ccard.js',
+    '../../../../js/prototype/validation.js',
+
+    // Scriptaculous is not needed when using bootstrap
+    // '../../../../js/scriptaculous/builder.js',
+    // '../../../../js/scriptaculous/effects.js',
+    // '../../../../js/scriptaculous/dragdrop.js',
+    // '../../../../js/scriptaculous/controls.js',
+    // '../../../../js/scriptaculous/slider.js',
+
+    '../../../../js/varien/js.js',
+    '../../../../js/varien/form.js',
+    '../../../../js/mage/translate.js',
+    '../../../../js/mage/cookies.js'
+  ];
+
+  var mage = gulp
+    .src(core)
+    .pipe(concat('mage.js'));
+
   var scripts = [
     'bower_components/jquery/dist/jquery.js',
     'bower_components/bootstrap/js/transition.js',
@@ -81,16 +104,19 @@ gulp.task('js', function() {
     scripts.push('src/js/livereload.js');
   }
 
-  var stream = gulp
+  var boilerplate = gulp
     .src(scripts)
     .pipe(concat('script.js'));
 
   if (config.uglifyJS === true) {
-    stream.pipe(uglify());
+    mage.pipe(uglify());
+    boilerplate.pipe(uglify());
   }
 
-  return stream
-    .pipe(gulp.dest('js'))
+  mage.pipe(gulp.dest('../../../../js')); // Put concated mage core js file in /js
+  boilerplate.pipe(gulp.dest('js'));
+
+  return merge(mage, boilerplate)
     .pipe(notify({ message: 'Successfully compiled JavaScript' }));
 });
 

--- a/skin/frontend/boilerplate/default/package.json
+++ b/skin/frontend/boilerplate/default/package.json
@@ -11,6 +11,7 @@
     "gulp-notify": "^1.4.0",
     "gulp-rimraf": "^0.1.0",
     "gulp-uglify": "^0.3.1",
+    "merge-stream": "~1.0",
 	"bower": "~1.3.5",
     "grunt": "~0.4.5",
     "grunt-autoprefixer": "~0.8.1",


### PR DESCRIPTION
This fixes #100 and addresses #111.

The most frequently used Magento core JS files are concatenated into one file, minimizing HTTP requests. The uglification processs might destroy some prototype function, I think I've stumbled accross a blog post somewhere, but this is highly speculative and has not been tested. So far, at least product page still works. :)