### PR TITLE
Fix undefined helper in MagentoBoilerplate

### DIFF
--- a/app/code/community/Webcomm/MagentoBoilerplate/etc/config.xml
+++ b/app/code/community/Webcomm/MagentoBoilerplate/etc/config.xml
@@ -37,6 +37,11 @@
                 <class>Webcomm_MagentoBoilerplate_Model</class>
             </magentoboilerplate>
         </models>
+	<helpers>
+            <magentoboilerplate>
+                <class>Webcomm_MagentoBoilerplate_Helper</class>
+            </magentoboilerplate>
+        </helpers>
         <events>
             <core_layout_update_updates_get_after>
                 <observers>


### PR DESCRIPTION
Without this patch the following error occurs:

```
2016-02-24T11:24:08+00:00 ERR (3): Warning: include(Mage/Magentoboilerplate/Helper/Data.php): failed to open stream: No such file or directory  in /Users/ccarnell/Sites/xx/lib/Varien/Autoload.php on line 94
2016-02-24T11:24:08+00:00 ERR (3): Warning: include(): Failed opening 'Mage/Magentoboilerplate/Helper/Data.php' for inclusion (include_path='/Users/ccarnell/Sites/xx/vendor/phpseclib/phpseclib/phpseclib:/Users/ccarnell/Sites/xx/app/code/local:/Users/ccarnell/Sites/careline/app/code/community:/Users/ccarnell/Sites/xx/app/code/core:/Users/ccarnell/Sites/careline/lib:.:')  in /Users/ccarnell/Sites/xx/lib/Varien/Autoload.php on line 94
```