### PR TITLE
Add support for PHP 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,16 @@ Begin by creating a `composer.json` in the root of Magento, and ensure it has th
         {
            "type": "vcs",
            "url": "https://github.com/magento-hackathon/magento-composer-installer"
+       },
+       {
+            "url": "https://github.com/Inchoo/Inchoo_PHP7.git",
+            "type": "git"
         }
     ],
     "require": {
         "magento-hackathon/magento-composer-installer": "*",
-        "webcomm/magento-boilerplate": "2.0.x-dev"
+        "webcomm/magento-boilerplate": "2.0.x-dev",
+        "inchoo/php7": "*"
     },
     "extra": {
         "magento-root-dir": "./",


### PR DESCRIPTION
Adds PHP 7 support for Magento by pulling in a very simple extension during the composer install (provided by Inchoo, see: http://inchoo.net/magento/its-alive/). Magento runs much much faster on PHP 7 and it's actually very easy to provide support with a tiny alteration.